### PR TITLE
feature/letsencrypt_multi_domain - support multiple domain names

### DIFF
--- a/go/letsencrypt/README.md
+++ b/go/letsencrypt/README.md
@@ -64,7 +64,7 @@ This producer accepts the following arguments:
 
 | Field name | Description |
 |-|-|
-| `domain` | Required: Issue Let's Encrypt certificate for this domain. |
+| `domain` | Required: A comma seperated domain list to issue in Let's Encrypt certificate. The first domain is used for the `CommonName` field of the certificate, all other domains are added using the `Subject Alternate Names` extension |
 | `use_staging` | Use Let's Encrypt staging environment. Useful during testing or integration to avoid rate limits. |
 
 For example:

--- a/go/letsencrypt/internal/producer/producer.go
+++ b/go/letsencrypt/internal/producer/producer.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-acme/lego/v4/certificate"
 	"github.com/go-acme/lego/v4/lego"
@@ -130,7 +131,8 @@ func obtainCertificate(email string, inp Input) (*certOutput, error) {
 		return nil, fmt.Errorf("can't obtain lets encrypt registration for %s: %w", email, err)
 	}
 
-	out, err := client.Certificate.Obtain(certificate.ObtainRequest{Domains: inp.Domain})
+	domainList := strings.Split(inp.Domain, ",")
+	out, err := client.Certificate.Obtain(certificate.ObtainRequest{Domains: domainList})
 	if err != nil {
 		return nil, fmt.Errorf("can't obtain certificates for domain %v: %w", inp.Domain, err)
 	}

--- a/go/letsencrypt/internal/producer/producer.go
+++ b/go/letsencrypt/internal/producer/producer.go
@@ -130,7 +130,7 @@ func obtainCertificate(email string, inp Input) (*certOutput, error) {
 		return nil, fmt.Errorf("can't obtain lets encrypt registration for %s: %w", email, err)
 	}
 
-	out, err := client.Certificate.Obtain(certificate.ObtainRequest{Domains: []string{inp.Domain}})
+	out, err := client.Certificate.Obtain(certificate.ObtainRequest{Domains: inp.Domain})
 	if err != nil {
 		return nil, fmt.Errorf("can't obtain certificates for domain %v: %w", inp.Domain, err)
 	}

--- a/go/letsencrypt/internal/producer/types.go
+++ b/go/letsencrypt/internal/producer/types.go
@@ -22,8 +22,8 @@ type CreateRequest struct {
 // Input includes variables specific to Let's Encrypt producer. The input
 // should be provided with `get-dynamic-secret-value` operation.
 type Input struct {
-	UseStaging bool   `json:"use_staging"`
-	Domain     string `json:"domain"`
+	UseStaging bool     `json:"use_staging"`
+	Domain     []string `json:"domain"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/go/letsencrypt/internal/producer/types.go
+++ b/go/letsencrypt/internal/producer/types.go
@@ -22,8 +22,8 @@ type CreateRequest struct {
 // Input includes variables specific to Let's Encrypt producer. The input
 // should be provided with `get-dynamic-secret-value` operation.
 type Input struct {
-	UseStaging bool     `json:"use_staging"`
-	Domain     []string `json:"domain"`
+	UseStaging bool   `json:"use_staging"`
+	Domain     string `json:"domain"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.


### PR DESCRIPTION
Support multiple domains:

The first domain in domains is used for the CommonName field of the certificate,
all other domains are added using the Subject Alternate Names extension